### PR TITLE
Apply syntax highlighting to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ user_repository.find(1) # => :not_found
 `ignore_extra_args` will allow a demonstration to be considered satisfied even
 if it fails to specify arguments and keyword arguments made by the actual call:
 
-```
+```ruby
 stubs { user_repository.find(4) }.with { :a_person }
 user_repository.find(4, debug: true) # => nil
 


### PR DESCRIPTION
This applies the ruby language identifier to a code block in the README
that previously did not specify a language to use for syntax
highlighting.