### PR TITLE
Ensure that type replacements are threadsafe

### DIFF
--- a/lib/mocktail/value/top_shelf.rb
+++ b/lib/mocktail/value/top_shelf.rb
@@ -1,65 +1,60 @@
-# The top shelf stores all cross-thread & thread-aware state, so anything that
-# goes here is on its own when it comes to ensuring thread safety.
 module Mocktail
   class TopShelf
     def self.instance
-      @self ||= new
+      Thread.current[:mocktail_top_shelf] ||= new
     end
 
+    @@type_replacements = {}
+    @@type_replacements_mutex = Mutex.new
+
     def initialize
-      @type_replacements = {}
-      @new_registrations = {}
-      @of_next_registrations = {}
-      @singleton_method_registrations = {}
+      @new_registrations = []
+      @of_next_registrations = []
+      @singleton_method_registrations = []
     end
 
     def type_replacement_for(type)
-      @type_replacements[type] ||= TypeReplacement.new(type: type)
+      @@type_replacements_mutex.synchronize {
+        @@type_replacements[type] ||= TypeReplacement.new(type: type)
+      }
     end
 
     def type_replacement_if_exists_for(type)
-      @type_replacements[type]
+      @@type_replacements_mutex.synchronize {
+        @@type_replacements[type]
+      }
     end
 
     def reset_current_thread!
-      @new_registrations[Thread.current] = []
-      @of_next_registrations[Thread.current] = []
-      @singleton_method_registrations[Thread.current] = []
+      Thread.current[:mocktail_top_shelf] = self.class.new
     end
 
     def register_new_replacement!(type)
-      @new_registrations[Thread.current] ||= []
-      @new_registrations[Thread.current] |= [type]
+      @new_registrations |= [type]
     end
 
     def new_replaced?(type)
-      @new_registrations[Thread.current] ||= []
-      @new_registrations[Thread.current].include?(type)
+      @new_registrations.include?(type)
     end
 
     def register_of_next_replacement!(type)
-      @of_next_registrations[Thread.current] ||= []
-      @of_next_registrations[Thread.current] |= [type]
+      @of_next_registrations |= [type]
     end
 
     def of_next_registered?(type)
-      @of_next_registrations[Thread.current] ||= []
-      @of_next_registrations[Thread.current].include?(type)
+      @of_next_registrations.include?(type)
     end
 
     def unregister_of_next_replacement!(type)
-      @of_next_registrations[Thread.current] ||= []
-      @of_next_registrations[Thread.current] -= [type]
+      @of_next_registrations -= [type]
     end
 
     def register_singleton_method_replacement!(type)
-      @singleton_method_registrations[Thread.current] ||= []
-      @singleton_method_registrations[Thread.current] |= [type]
+      @singleton_method_registrations |= [type]
     end
 
     def singleton_methods_replaced?(type)
-      @singleton_method_registrations[Thread.current] ||= []
-      @singleton_method_registrations[Thread.current].include?(type)
+      @singleton_method_registrations.include?(type)
     end
   end
 end


### PR DESCRIPTION
Modifying a Hash from multiple threads is potentially dangerous, even if threads don't access the same key.

To avoid this, make `Mocktail::TopShelf` a thread-local singleton.

The list of type replacements corresponds to _global_ changes, so those are represented as a class variable and wrapped in a Mutex.