### PR TITLE
Ignore double-equals method when creating class double

### DIFF
--- a/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
+++ b/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
@@ -38,9 +38,12 @@ module Mocktail
 
     private
 
+    IGNORED_METHODS = [:==]
+    private_constant :IGNORED_METHODS
+
     def define_double_methods!(dry_class, type, instance_methods)
       handles_dry_call = @handles_dry_call
-      instance_methods.each do |method|
+      (instance_methods - IGNORED_METHODS).each do |method|
         dry_class.define_method method, ->(*args, **kwargs, &block) {
           handles_dry_call.handle(Call.new(
             singleton: false,

--- a/test/safe/of_test.rb
+++ b/test/safe/of_test.rb
@@ -91,4 +91,13 @@ class OfTest < Minitest::Test
   def test_constructors_dont_require_args
     assert Mocktail.of(Argz)
   end
+
+  class DoubleEquals
+    def ==(other)
+    end
+  end
+
+  def test_double_equals_doesnt_infinite_loop
+    assert Mocktail.of(DoubleEquals)
+  end
 end


### PR DESCRIPTION
The double-equals method, when defined on a dry class, causes an infinite loop
which then results in a stack overflow.

Closes #7