### PR TITLE
Add failing test for options hash arity

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,30 +9,32 @@ GEM
     ast (2.4.2)
     coderay (1.1.3)
     docile (1.4.0)
+    json (2.6.2)
     method_source (1.0.0)
-    minitest (5.15.0)
+    minitest (5.16.3)
     parallel (1.22.1)
-    parser (3.1.2.0)
+    parser (3.1.2.1)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.3.0)
+    regexp_parser (2.6.0)
     rexml (3.2.5)
-    rubocop (1.27.0)
+    rubocop (1.35.1)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.0.0)
+      parser (>= 3.1.2.1)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.16.0, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.20.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.17.0)
+    rubocop-ast (1.23.0)
       parser (>= 3.1.1.0)
-    rubocop-performance (1.13.3)
+    rubocop-performance (1.14.3)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
@@ -42,14 +44,13 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    standard (1.10.0)
-      rubocop (= 1.27.0)
-      rubocop-performance (= 1.13.3)
-    unicode-display_width (2.1.0)
+    standard (1.16.1)
+      rubocop (= 1.35.1)
+      rubocop-performance (= 1.14.3)
+    unicode-display_width (2.3.0)
 
 PLATFORMS
-  arm64-darwin-20
-  ruby
+  arm64-darwin-21
 
 DEPENDENCIES
   minitest
@@ -60,4 +61,4 @@ DEPENDENCIES
   standard
 
 BUNDLED WITH
-   2.3.6
+   2.3.16

--- a/lib/mocktail.rb
+++ b/lib/mocktail.rb
@@ -1,3 +1,4 @@
+require_relative "mocktail/builds_method_signature"
 require_relative "mocktail/collects_calls"
 require_relative "mocktail/debug"
 require_relative "mocktail/dsl"

--- a/lib/mocktail/builds_method_signature.rb
+++ b/lib/mocktail/builds_method_signature.rb
@@ -15,7 +15,6 @@ module Mocktail
       end
     end
 
-
     def positional
       @signature.positional_params.all.map do |name|
         if @signature.positional_params.required.include?(name)
@@ -45,7 +44,7 @@ module Mocktail
 
     def block
       if dotdotdot.empty? && @signature.block_param
-         "&block"
+        "&block"
       else
         ""
       end

--- a/lib/mocktail/builds_method_signature.rb
+++ b/lib/mocktail/builds_method_signature.rb
@@ -1,0 +1,54 @@
+module Mocktail
+  class BuildsMethodSignature
+    def build(signature)
+      @signature = signature
+      "(#{[positional, keyword, block, dotdotdot].reject(&:empty?).join(", ")})"
+    end
+
+    def dotdotdot
+      @dotdotdot ||= if @signature.positional_params.rest == :* &&
+          @signature.keyword_params.rest == :** &&
+          @signature.block_param == :&
+        "..."
+      else
+        ""
+      end
+    end
+
+
+    def positional
+      @signature.positional_params.all.map do |name|
+        if @signature.positional_params.required.include?(name)
+          name.to_s
+        elsif @signature.positional_params.optional.include?(name)
+          "#{name} = nil"
+        elsif @signature.positional_params.rest == name && name != :*
+          "*#{name}"
+        end
+      end.compact.join(", ")
+    end
+
+    def keyword
+      if dotdotdot.empty?
+        @signature.keyword_params.all.map do |name|
+          if @signature.keyword_params.required.include?(name)
+            "#{name}:"
+          elsif @signature.keyword_params.optional.include?(name)
+            "#{name}: nil"
+          elsif @signature.keyword_params.rest == name && name != :**
+            "**#{name}" end
+        end.join(", ")
+      else
+        ""
+      end
+    end
+
+    def block
+      if dotdotdot.empty? && @signature.block_param
+         "&block"
+      else
+        ""
+      end
+    end
+  end
+end

--- a/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
+++ b/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
@@ -3,6 +3,8 @@ module Mocktail
     def initialize
       @handles_dry_call = HandlesDryCall.new
       @raises_neato_no_method_error = RaisesNeatoNoMethodError.new
+      @transforms_params = TransformsParams.new
+      @builds_method_signature = BuildsMethodSignature.new
     end
 
     def declare(type, instance_methods)
@@ -42,21 +44,28 @@ module Mocktail
       handles_dry_call = @handles_dry_call
       instance_methods.each do |method|
         dry_class.undef_method(method) if dry_class.method_defined?(method)
+        parameters = type.instance_method(method).parameters
+        signature = @transforms_params.transform(Call.new, params: parameters)
+        method_signature = @builds_method_signature.build(signature)
 
-        dry_class.define_method method, ->(*args, **kwargs, &block) {
-          Debug.guard_against_mocktail_accidentally_calling_mocks_if_debugging!
-          handles_dry_call.handle(Call.new(
-            singleton: false,
-            double: self,
-            original_type: type,
-            dry_type: dry_class,
-            method: method,
-            original_method: type.instance_method(method),
-            args: args,
-            kwargs: kwargs,
-            block: block
-          ))
-        }
+        # TODO: This is failing because none of self, type, dry_class, method,
+        # etc are in scope for the dry_class.
+        dry_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
+          def #{method}#{method_signature}
+            Debug.guard_against_mocktail_accidentally_calling_mocks_if_debugging!
+            HandlesDryClass.new.handle(Call.new(
+              singleton: false,
+              double: self,
+              original_type: type,
+              dry_type: dry_class,
+              method: method,
+              original_method: type.instance_method(method),
+              args: args,
+              kwargs: kwargs,
+              block: block
+            ))
+          end
+        RUBY
       end
     end
 

--- a/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
+++ b/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
@@ -50,22 +50,23 @@ module Mocktail
 
         # TODO: This is failing because none of self, type, dry_class, method,
         # etc are in scope for the dry_class.
-        dry_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
-          def #{method}#{method_signature}
-            Debug.guard_against_mocktail_accidentally_calling_mocks_if_debugging!
-            HandlesDryClass.new.handle(Call.new(
-              singleton: false,
-              double: self,
-              original_type: type,
-              dry_type: dry_class,
-              method: method,
-              original_method: type.instance_method(method),
-              args: args,
-              kwargs: kwargs,
-              block: block
-            ))
-          end
-        RUBY
+        dry_class.define_method method,
+          eval(<<-RUBY, binding, __FILE__, __LINE__ + 1)
+            ->#{method_signature} do
+              Debug.guard_against_mocktail_accidentally_calling_mocks_if_debugging!
+              handles_dry_call.handle(Call.new(
+                singleton: false,
+                double: self,
+                original_type: type,
+                dry_type: dry_class,
+                method: method,
+                original_method: type.instance_method(method),
+                args: args,
+                kwargs: kwargs,
+                block: block
+              ))
+            end
+          RUBY
       end
     end
 

--- a/lib/mocktail/simulates_argument_error/transforms_params.rb
+++ b/lib/mocktail/simulates_argument_error/transforms_params.rb
@@ -2,9 +2,7 @@ require_relative "../share/bind"
 
 module Mocktail
   class TransformsParams
-    def transform(dry_call)
-      params = dry_call.original_method.parameters
-
+    def transform(dry_call, params: dry_call.original_method.parameters)
       Signature.new(
         positional_params: Params.new(
           all: params.select { |t, _|
@@ -12,7 +10,7 @@ module Mocktail
           }.map { |_, name| name },
           required: params.select { |t, _| Bind.call(t, :==, :req) }.map { |_, n| n },
           optional: params.select { |t, _| Bind.call(t, :==, :opt) }.map { |_, n| n },
-          rest: params.find { |t, _| Bind.call(t, :==, :rest) } & [1]
+          rest: params.find { |t, _| Bind.call(t, :==, :rest) }&.last
         ),
         positional_args: dry_call.args,
 
@@ -22,11 +20,11 @@ module Mocktail
           }.map { |_, name| name },
           required: params.select { |t, _| Bind.call(t, :==, :keyreq) }.map { |_, n| n },
           optional: params.select { |t, _| Bind.call(t, :==, :key) }.map { |_, n| n },
-          rest: params.find { |t, _| Bind.call(t, :==, :keyrest) } & [1]
+          rest: params.find { |t, _| Bind.call(t, :==, :keyrest) }&.last
         ),
         keyword_args: dry_call.kwargs,
 
-        block_param: params.find { |t, _| Bind.call(t, :==, :block) } & [1],
+        block_param: params.find { |t, _| Bind.call(t, :==, :block) }&.last,
         block_arg: dry_call.block
       )
     end

--- a/test/unit/arity_test.rb
+++ b/test/unit/arity_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class ArityTest < Minitest::Test
+  class Charity
+    def donate(amount:); end
+    def give(opts); end
+  end
+
+  def test_handles_kwargs_and_hashes
+    aclu = Charity.new
+    aclu.donate(amount: 100)
+    aclu.give(to: :poor)
+
+    wbc = Mocktail.of(Charity)
+    wbc.donate(amount: 100)
+    wbc.give({ to: :poor })
+    wbc.give(to: :poor)
+  end
+end

--- a/test/unit/arity_test.rb
+++ b/test/unit/arity_test.rb
@@ -2,8 +2,11 @@ require "test_helper"
 
 class ArityTest < Minitest::Test
   class Charity
-    def donate(amount:); end
-    def give(opts); end
+    def donate(amount:)
+    end
+
+    def give(opts)
+    end
   end
 
   def test_handles_kwargs_and_hashes
@@ -13,7 +16,7 @@ class ArityTest < Minitest::Test
 
     wbc = Mocktail.of(Charity)
     wbc.donate(amount: 100)
-    wbc.give({ to: :poor })
+    wbc.give({to: :poor})
     wbc.give(to: :poor)
   end
 end

--- a/test/unit/builds_method_signature_test.rb
+++ b/test/unit/builds_method_signature_test.rb
@@ -11,62 +11,55 @@ module Mocktail
     end
 
     def test_positional_call
-      assert_equal @subject.build(signature(
+      assert_equal "(a, b)", @subject.build(signature(
         positional_params: Params.new(all: [:a, :b], required: [:a, :b]),
-      )),
-     "(a, b)"
+      ))     
     end
 
     def test_optional_positional_call
-      assert_equal @subject.build(signature(
+      assert_equal "(a = nil, b)", @subject.build(signature(
         positional_params: Params.new(
           all: [:a, :b],
           required: [:b],
           optional: [:a]
         ),
-      )),
-     "(a = nil, b)"
+      ))
     end
 
     def test_kwarg_call
-      assert_equal @subject.build(signature(
+      assert_equal "(a: nil, b:)", @subject.build(signature(
         keyword_params: Params.new(
           all: [:a, :b],
           required: [:b],
           optional: [:a]
         ),
-      )),
-     "(a: nil, b:)"
+      ))
     end
 
     def test_block_call
-      assert_equal @subject.build(signature(
+      assert_equal "(&block)", @subject.build(signature(
         block_param: [],
-      )),
-     "(&block)"
+      ))
     end
 
     def test_rest_call
-      assert_equal @subject.build(signature(
+      assert_equal "(*args)", @subject.build(signature(
         positional_params: Params.new(all: [:args], rest: :args),
-      )),
-     "(*args)"
+      ))
     end
 
     def test_kwrest_call
-      assert_equal @subject.build(signature(
+      assert_equal "(**kwargs)", @subject.build(signature(
         keyword_params: Params.new(all: [:kwargs], rest: :kwargs),
-      )),
-     "(**kwargs)"
+      ))
     end
 
     def test_complex_call
-      assert_equal @subject.build(signature(
+      assert_equal "(a, b = nil, *args, c:, d: nil, **kwargs, &block)", @subject.build(signature(
         positional_params: Params.new(all: [:a, :b, :args], required: [:a], optional: [:b], rest: :args),
         keyword_params: Params.new(all: [:c, :d, :kwargs], required: [:c], optional: [:d], rest: :kwargs),
         block_param: [:block],
-      )),
-     "(a, b = nil, *args, c:, d: nil, **kwargs, &block)"
+      ))
     end
 
     def test_dotdotdot_call
@@ -74,7 +67,8 @@ module Mocktail
         Call.new,
         params: method(:dotdotdot).parameters
       )
-      assert_equal @subject.build(sig), "(...)"
+
+      assert_equal "(...)", @subject.build(sig)
     end
 
     def test_dotdotdot_with_args_call
@@ -82,7 +76,8 @@ module Mocktail
         Call.new,
         params: method(:dotdotdot_with_args).parameters
       )
-      assert_equal @subject.build(sig), "(a, b = nil, ...)"
+
+      assert_equal "(a, b = nil, ...)", @subject.build(sig)
     end
 
     def dotdotdot(...); end

--- a/test/unit/builds_method_signature_test.rb
+++ b/test/unit/builds_method_signature_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+module Mocktail
+  class BuildsMethodSignatureTest < Minitest::Test
+    def setup
+      @subject = BuildsMethodSignature.new
+    end
+
+    def test_basic_call
+      assert_equal @subject.build(signature), "()"
+    end
+
+    def test_positional_call
+      assert_equal @subject.build(signature(
+        positional_params: Params.new(all: [:a, :b], required: [:a, :b]),
+      )),
+     "(a, b)"
+    end
+
+    def test_optional_positional_call
+      assert_equal @subject.build(signature(
+        positional_params: Params.new(
+          all: [:a, :b],
+          required: [:b],
+          optional: [:a]
+        ),
+      )),
+     "(a = nil, b)"
+    end
+
+    def test_kwarg_call
+      assert_equal @subject.build(signature(
+        keyword_params: Params.new(
+          all: [:a, :b],
+          required: [:b],
+          optional: [:a]
+        ),
+      )),
+     "(a: nil, b:)"
+    end
+
+    def test_block_call
+      assert_equal @subject.build(signature(
+        block_param: [],
+      )),
+     "(&block)"
+    end
+
+    def test_rest_call
+      assert_equal @subject.build(signature(
+        positional_params: Params.new(all: [:args], rest: :args),
+      )),
+     "(*args)"
+    end
+
+    def test_kwrest_call
+      assert_equal @subject.build(signature(
+        keyword_params: Params.new(all: [:kwargs], rest: :kwargs),
+      )),
+     "(**kwargs)"
+    end
+
+    def test_complex_call
+      assert_equal @subject.build(signature(
+        positional_params: Params.new(all: [:a, :b, :args], required: [:a], optional: [:b], rest: :args),
+        keyword_params: Params.new(all: [:c, :d, :kwargs], required: [:c], optional: [:d], rest: :kwargs),
+        block_param: [:block],
+      )),
+     "(a, b = nil, *args, c:, d: nil, **kwargs, &block)"
+    end
+
+    def test_dotdotdot_call
+      sig = TransformsParams.new.transform(
+        Call.new,
+        params: method(:dotdotdot).parameters
+      )
+      assert_equal @subject.build(sig), "(...)"
+    end
+
+    def test_dotdotdot_with_args_call
+      sig = TransformsParams.new.transform(
+        Call.new,
+        params: method(:dotdotdot_with_args).parameters
+      )
+      assert_equal @subject.build(sig), "(a, b = nil, ...)"
+    end
+
+    def dotdotdot(...); end
+    def dotdotdot_with_args(a, b = :foo, ...); end
+
+    def signature(positional_params: Params.new(all: []), keyword_params: Params.new(all: []), block_param: false)
+      Signature.new(
+        positional_params: positional_params,
+        positional_args: [],
+        keyword_params: keyword_params,
+        keyword_args: {},
+        block_param: block_param,
+        block_arg: nil
+      )
+    end
+  end
+end


### PR DESCRIPTION
While Ruby supports options hashes without braces, Mocktail currently
does not.