### PR TITLE
Fix == infinite loop

### DIFF
--- a/lib/mocktail.rb
+++ b/lib/mocktail.rb
@@ -1,3 +1,4 @@
+require_relative "mocktail/debug"
 require_relative "mocktail/dsl"
 require_relative "mocktail/errors"
 require_relative "mocktail/explains_thing"

--- a/lib/mocktail/debug.rb
+++ b/lib/mocktail/debug.rb
@@ -1,0 +1,49 @@
+module Mocktail
+  module Debug
+    # It would be easy and bad for the mocktail lib to call something like
+    #
+    #   double == other_double
+    #
+    # But if it's a double, that means anyone who stubs that method could change
+    # the internal behavior of the library in unexpected ways (as happened here:
+    # https://github.com/testdouble/mocktail/issues/7 )
+    #
+    # For that reason when we run our tests, we also want to blow up if this
+    # happens unintentionally. This works in conjunction with the test
+    # MockingMethodfulClassesTest, because it mocks every defined method on the
+    # mocked BasicObject
+    def self.guard_against_mocktail_accidentally_calling_mocks_if_debugging!
+      return unless ENV["MOCKTAIL_DEBUG_ACCIDENTAL_INTERNAL_MOCK_CALLS"]
+      raise
+    rescue => e
+      base_path = Pathname.new(__FILE__).dirname.to_s
+      backtrace_minus_this_and_whoever_called_this = e.backtrace[2..]
+      internal_call_sites = backtrace_minus_this_and_whoever_called_this.take_while { |call_site|
+        # the "in `block" is very confusing but necessary to include lines after
+        # a stubs { blah.foo }.with { … } call, since that's when most of the
+        # good stuff happens
+        call_site.start_with?(base_path) || call_site.include?("in `block")
+      }.reject { |call_site| call_site.include?("in `block") }
+
+      approved_call_sites = [
+        "fulfills_stubbing.rb:14",
+        "validates_arguments.rb:16",
+        "validates_arguments.rb:19"
+      ]
+      if internal_call_sites.any? && approved_call_sites.none? { |approved_call_site|
+        internal_call_sites.first.include?(approved_call_site)
+      }
+        raise Error.new <<~MSG
+          Unauthorized internal call of a mock internally by Mocktail itself:
+
+          #{internal_call_sites.first}
+
+          Offending call's complete stack trace:
+
+          #{backtrace_minus_this_and_whoever_called_this.join("\n")}
+          ==END OFFENDING TRACE==
+        MSG
+      end
+    end
+  end
+end

--- a/lib/mocktail/handles_dry_call/fulfills_stubbing/describes_unsatisfied_stubbing.rb
+++ b/lib/mocktail/handles_dry_call/fulfills_stubbing/describes_unsatisfied_stubbing.rb
@@ -1,17 +1,19 @@
 require_relative "../../share/cleans_backtrace"
+require_relative "../../share/compares_safely"
 
 module Mocktail
   class DescribesUnsatisfiedStubbing
     def initialize
       @cleans_backtrace = CleansBacktrace.new
+      @compares_safely = ComparesSafely.new
     end
 
     def describe(dry_call)
       UnsatisfyingCall.new(
         call: dry_call,
         other_stubbings: Mocktail.cabinet.stubbings.select { |stubbing|
-          dry_call.double == stubbing.recording.double &&
-            dry_call.method == stubbing.recording.method
+          @compares_safely.compare(dry_call.double, stubbing.recording.double) &&
+            @compares_safely.compare(dry_call.method, stubbing.recording.method)
         },
         backtrace: @cleans_backtrace.clean(Error.new).backtrace
       )

--- a/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
+++ b/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
@@ -44,6 +44,7 @@ module Mocktail
         dry_class.undef_method(method) if dry_class.method_defined?(method)
 
         dry_class.define_method method, ->(*args, **kwargs, &block) {
+          Debug.guard_against_mocktail_accidentally_calling_mocks_if_debugging!
           handles_dry_call.handle(Call.new(
             singleton: false,
             double: self,

--- a/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
+++ b/lib/mocktail/imitates_type/makes_double/declares_dry_class.rb
@@ -41,6 +41,8 @@ module Mocktail
     def define_double_methods!(dry_class, type, instance_methods)
       handles_dry_call = @handles_dry_call
       instance_methods.each do |method|
+        dry_class.undef_method(method) if dry_class.method_defined?(method)
+
         dry_class.define_method method, ->(*args, **kwargs, &block) {
           handles_dry_call.handle(Call.new(
             singleton: false,

--- a/lib/mocktail/share/compares_safely.rb
+++ b/lib/mocktail/share/compares_safely.rb
@@ -1,0 +1,7 @@
+module Mocktail
+  class ComparesSafely
+    def compare(thing, other_thing)
+      Object.instance_method(:==).bind_call(thing, other_thing)
+    end
+  end
+end

--- a/lib/mocktail/share/determines_matching_calls.rb
+++ b/lib/mocktail/share/determines_matching_calls.rb
@@ -1,8 +1,14 @@
+require_relative "compares_safely"
+
 module Mocktail
   class DeterminesMatchingCalls
+    def initialize
+      @compares_safely = ComparesSafely.new
+    end
+
     def determine(real_call, demo_call, demo_config)
-      real_call.double == demo_call.double &&
-        real_call.method == demo_call.method &&
+      @compares_safely.compare(real_call.double, demo_call.double) &&
+        @compares_safely.compare(real_call.method, demo_call.method) &&
 
         # Matcher implementation will replace this:
         args_match?(real_call.args, demo_call.args, demo_config.ignore_extra_args) &&
@@ -53,7 +59,7 @@ module Mocktail
           demo_arg.is_mocktail_matcher?
         demo_arg.match?(real_arg)
       else
-        demo_arg == real_arg
+        demo_arg == real_arg # TODO <-- test if mock object and call safe compare if so, otherwise ==
       end
     end
   end

--- a/lib/mocktail/simulates_argument_error/transforms_params.rb
+++ b/lib/mocktail/simulates_argument_error/transforms_params.rb
@@ -1,16 +1,22 @@
+require_relative "../share/compares_safely"
+
 module Mocktail
   class TransformsParams
+    def initialize
+      @compares_safely = ComparesSafely.new
+    end
+
     def transform(dry_call)
       params = dry_call.original_method.parameters
 
       Signature.new(
         positional_params: Params.new(
-          all: params.select { |type, _|
-            [:req, :opt, :rest].include?(type)
+          all: params.select { |t, _|
+            [:req, :opt, :rest].any? { |param_type| @compares_safely.compare(t, param_type) }
           }.map { |_, name| name },
-          required: params.select { |t, _| t == :req }.map { |_, n| n },
-          optional: params.select { |t, _| t == :opt }.map { |_, n| n },
-          rest: params.find { |type, _| type == :rest } & [1]
+          required: params.select { |t, _| @compares_safely.compare(t, :req) }.map { |_, n| n },
+          optional: params.select { |t, _| @compares_safely.compare(t, :opt) }.map { |_, n| n },
+          rest: params.find { |t, _| @compares_safely.compare(t, :rest) } & [1]
         ),
         positional_args: dry_call.args,
 
@@ -18,13 +24,13 @@ module Mocktail
           all: params.select { |type, _|
             [:keyreq, :key, :keyrest].include?(type)
           }.map { |_, name| name },
-          required: params.select { |t, _| t == :keyreq }.map { |_, n| n },
-          optional: params.select { |t, _| t == :key }.map { |_, n| n },
-          rest: params.find { |type, _| type == :keyrest } & [1]
+          required: params.select { |t, _| @compares_safely.compare(t, :keyreq) }.map { |_, n| n },
+          optional: params.select { |t, _| @compares_safely.compare(t, :key) }.map { |_, n| n },
+          rest: params.find { |t, _| @compares_safely.compare(t, :keyrest) } & [1]
         ),
         keyword_args: dry_call.kwargs,
 
-        block_param: params.find { |type, _| type == :block } & [1],
+        block_param: params.find { |t, _| @compares_safely.compare(t, :block) } & [1],
         block_arg: dry_call.block
       )
     end

--- a/test/safe/mocking_methodful_classes_test.rb
+++ b/test/safe/mocking_methodful_classes_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class MockingMethodfulClassesTest < Minitest::Test
+  include Mocktail::DSL
+
+  class OverridesEquals
+    def normal_method
+    end
+
+    def ==(other)
+      super
+    end
+  end
+
+  def test_overriding_equals
+    overrides_equals = Mocktail.of(OverridesEquals)
+
+    overrides_equals.normal_method
+    stubs { overrides_equals.normal_method }.with { 32 }
+
+    assert_equal overrides_equals.normal_method, 32
+  end
+end

--- a/test/safe/mocking_methodful_classes_test.rb
+++ b/test/safe/mocking_methodful_classes_test.rb
@@ -37,7 +37,16 @@ class MockingMethodfulClassesTest < Minitest::Test
 
     overrides_everything.normal_method
     stubs { overrides_everything.normal_method }.with { 32 }
+    stubs { |m| overrides_everything == m.any }.with { false }
+    stubs { overrides_everything == 3 }.with { true }
 
     assert_equal overrides_everything.normal_method, 32
+    assert_equal overrides_everything == 3, true
+    assert_equal overrides_everything == 2, false
+
+    explanation = Mocktail.explain(overrides_everything)
+    assert_equal explanation.reference.stubbings[0].satisfaction_count, 1
+    assert_equal explanation.reference.stubbings[1].satisfaction_count, 1
+    assert_equal explanation.reference.stubbings[2].satisfaction_count, 1
   end
 end

--- a/test/safe/mocking_methodful_classes_test.rb
+++ b/test/safe/mocking_methodful_classes_test.rb
@@ -20,4 +20,24 @@ class MockingMethodfulClassesTest < Minitest::Test
 
     assert_equal overrides_equals.normal_method, 32
   end
+
+  class OverridesEverything
+    (instance_methods - [:__send__, :object_id]).each do |method|
+      define_method method, ->(*args, **kwargs, &block) {
+        super
+      }
+    end
+
+    def normal_method
+    end
+  end
+
+  def test_overriding_everything
+    overrides_everything = Mocktail.of(OverridesEverything)
+
+    overrides_everything.normal_method
+    stubs { overrides_everything.normal_method }.with { 32 }
+
+    assert_equal overrides_everything.normal_method, 32
+  end
 end

--- a/test/safe/mocking_methodful_classes_test.rb
+++ b/test/safe/mocking_methodful_classes_test.rb
@@ -43,7 +43,9 @@ class MockingMethodfulClassesTest < Minitest::Test
     assert_equal overrides_everything.normal_method, 32
     assert_equal overrides_everything == 3, true
     assert_equal overrides_everything == 2, false
-
+    verify { overrides_everything.normal_method }
+    verify { overrides_everything == 3 }
+    verify(times: 0) { overrides_everything == 4 }
     explanation = Mocktail.explain(overrides_everything)
     assert_equal explanation.reference.stubbings[0].satisfaction_count, 1
     assert_equal explanation.reference.stubbings[1].satisfaction_count, 1

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@ SimpleCov.start do
   add_filter "/test/"
 end
 
+ENV["MOCKTAIL_DEBUG_ACCIDENTAL_INTERNAL_MOCK_CALLS"] = "true"
+
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "mocktail"
 


### PR DESCRIPTION
This was a long-suffering fix because nailing it down was really confusing.

In short, Mocktail was calling `==` on mocks that it had created, which meant if you faked those methods (by defining them on the faked class and calling `Mocktail.of`, for example), `==` would return `nil` instead of behaving correctly. We fixed this by being sure to call `BaseObject.bind(mock).==(other_thing)`

Additionally, to guard against future cases of us accidentally calling methods on mocks, I added a debug mode that is tripped on whenever the tests run. Since we have 100% code coverage, this will hopefully be caught by our test that mocks an object that redefines everything on `Object`.

Thanks to @kbaribeau for pairing with me on this. And thanks to several people at RailsConf 2022 who worked with me on this at the TD Lounge pairing event! 

Fixes #7 