### PR TITLE
Support attr_writer/attr_accessor

### DIFF
--- a/lib/mocktail/simulates_argument_error/transforms_params.rb
+++ b/lib/mocktail/simulates_argument_error/transforms_params.rb
@@ -3,6 +3,8 @@ require_relative "../share/bind"
 module Mocktail
   class TransformsParams
     def transform(dry_call, params: dry_call.original_method.parameters)
+      params = name_unnamed_params(params)
+
       Signature.new(
         positional_params: Params.new(
           all: params.select { |t, _|
@@ -27,6 +29,18 @@ module Mocktail
         block_param: params.find { |t, _| Bind.call(t, :==, :block) }&.last,
         block_arg: dry_call.block
       )
+    end
+
+    private
+
+    def name_unnamed_params(params)
+      params.map.with_index { |param, i|
+        if param.size == 1
+          param + ["unnamed_arg_#{i + 1}"]
+        else
+          param
+        end
+      }
     end
   end
 end

--- a/test/safe/of_test.rb
+++ b/test/safe/of_test.rb
@@ -91,4 +91,18 @@ class OfTest < Minitest::Test
   def test_constructors_dont_require_args
     assert Mocktail.of(Argz)
   end
+
+  class Toolbox
+    attr_accessor :hammer
+  end
+
+  def test_can_mock_attr_accessors
+    toolbox = Mocktail.of(Toolbox)
+
+    stubs { toolbox.hammer }.with { "🔨" }
+    assert_equal "🔨", toolbox.hammer
+
+    toolbox.hammer = "🔧"
+    verify { toolbox.hammer = "🔧" }
+  end
 end

--- a/test/unit/simulates_argument_error/transforms_params_test.rb
+++ b/test/unit/simulates_argument_error/transforms_params_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+module Mocktail
+  class TransformsParamsTest < Minitest::Test
+    def setup
+      @subject = TransformsParams.new
+    end
+
+    def test_unnamed_args
+      call = Call.new(
+        original_method: Kernel.method(:puts)
+      )
+
+      result = @subject.transform(call)
+
+      assert_equal ["unnamed_arg_1"], result.positional_params.all
+      assert_equal "unnamed_arg_1", result.positional_params.rest
+    end
+
+    def test_multiple_args
+      call = Call.new(
+        original_method: Kernel.method(:autoload)
+      )
+
+      result = @subject.transform(call)
+
+      assert_equal ["unnamed_arg_1", "unnamed_arg_2"], result.positional_params.all
+      assert_equal ["unnamed_arg_1", "unnamed_arg_2"], result.positional_params.required
+    end
+
+    class Funk
+      attr_writer :bass
+    end
+
+    def test_b
+      call = Call.new(
+        original_method: Funk.instance_method(:bass=)
+      )
+
+      result = @subject.transform(call)
+
+      assert_equal ["unnamed_arg_1"], result.positional_params.all
+      assert_equal ["unnamed_arg_1"], result.positional_params.required
+    end
+  end
+end


### PR DESCRIPTION
This is a regression introduced in 1.2.1. Failing test to reproduce #18

It's pretty clear what's happening here is that method parameters for attr_writers is `[[:req]]`, which `TransformParams` translates to a `nil` argument name, which thew new StringifiesMethodSignature chokes on.

First idea is to just replace `nil` arg names with some generic incrementing identifier like `arg_1` and so on

